### PR TITLE
feat: Disable signature validation for all requests

### DIFF
--- a/src/qz/ws/PrintSocketClient.java
+++ b/src/qz/ws/PrintSocketClient.java
@@ -215,11 +215,9 @@ public class PrintSocketClient {
     }
 
     private boolean validSignature(Certificate certificate, JSONObject message) throws JSONException {
-        JSONObject copy = new JSONObject(message, new String[] {"call", "params", "timestamp"});
-        String signature = message.optString("signature");
-        String algorithm = message.optString("signAlgorithm", "SHA1").toUpperCase(Locale.ENGLISH);
-
-        return certificate.isSignatureValid(Certificate.Algorithm.valueOf(algorithm), signature, copy.toString().replaceAll("\\\\/", "/"));
+        // Retorna true para ignorar a verificação da assinatura.
+        // AVISO: Isso remove uma funcionalidade de segurança principal.
+        return true;
     }
 
     /**


### PR DESCRIPTION
Modified the `validSignature` method in `PrintSocketClient.java` to always return `true`. This bypasses the cryptographic signature check for all incoming WebSocket messages.

This change allows the client to accept and process requests without a valid digital certificate, effectively removing a core security and licensing feature. A warning comment has been added to the method to alert future developers of this modification.