### PR TITLE
feat: Enable "Remember this decision" for anonymous requests

### DIFF
--- a/src/qz/ui/GatewayDialog.java
+++ b/src/qz/ui/GatewayDialog.java
@@ -86,7 +86,6 @@ public class GatewayDialog extends JDialog implements Themeable {
         bottomPanel.setLayout(new FlowLayout(FlowLayout.CENTER, 10, 5));
         persistentCheckBox = new JCheckBox(Constants.REMEMBER_THIS_DECISION, false);
         persistentCheckBox.setMnemonic(KeyEvent.VK_R);
-        persistentCheckBox.addActionListener(e -> allowButton.setEnabled(!persistentCheckBox.isSelected() || request.isVerified()));
         persistentCheckBox.setAlignmentX(RIGHT_ALIGNMENT);
 
         bottomPanel.add(certInfoLabel);


### PR DESCRIPTION
Removes the logic that disabled the "Allow" button when "Remember this decision" was checked for unverified (anonymous) requests. This allows users to persist their choice for all types of requests.