### PR TITLE
feat: Allow anonymous printing connections

### DIFF
--- a/src/qz/ws/PrintSocketClient.java
+++ b/src/qz/ws/PrintSocketClient.java
@@ -138,7 +138,11 @@ public class PrintSocketClient {
                     request.markNewConnection(Certificate.UNKNOWN);
                 }
 
-                if (allowedFromDialog(request, "connect to " + Constants.ABOUT_TITLE,
+                // Bypass dialog for anonymous connections to allow silent printing
+                if (request.getCertUsed() == Certificate.UNKNOWN) {
+                    log.info("Anonymous connection approved automatically.");
+                    sendResult(session, UID, null);
+                } else if (allowedFromDialog(request, "connect to " + Constants.ABOUT_TITLE,
                                       findDialogPosition(session, json.optJSONObject("position")))) {
                     sendResult(session, UID, null);
                 } else {


### PR DESCRIPTION
Modifies the WebSocket connection logic to automatically approve connections that do not provide a certificate.

This change bypasses the interactive approval dialog for anonymous requests, allowing for unattended/automated printing scenarios as requested by the user.

The `PrintSocketClient` now checks if a connection uses `Certificate.UNKNOWN` and, if so, sends a successful connection result without prompting for user approval.